### PR TITLE
Support for AD

### DIFF
--- a/entry.php
+++ b/entry.php
@@ -131,11 +131,12 @@ function _saveData(){
   $dn    = $_REQUEST['dn'];
   //construct new dn
   $new_uid = time().str_pad(mt_rand(0,99999999),8,"0", STR_PAD_LEFT);
-  $newdn = 'uid=';
-  if ($conf['cnasuid']) {
-    $newdn = 'cn=';
+  $entry['displayname'] = $entry['givenname'].' '.$entry['name'];
+  if ($conf['cnindn']) {
+    $newdn = 'cn='.$entry['displayname'];
+  }else{
+    $newdn = 'uid='.$new_uid;
   }
-  $newdn   .= $new_uid;
   if (empty($_REQUEST['type'])) { $_REQUEST['type']='public'; }
   if($_REQUEST['type'] == 'private' && $_SESSION['ldapab']['privatedn']){
     $newdn .= ','.$_SESSION['ldapab']['privatedn'];
@@ -165,6 +166,8 @@ print '</pre>';
     //modify entry attribute by attribute - this ensure we don't delete unknown stuff
     foreach (array_values($FIELDS) as $key){
       if($key == 'dn'){
+        continue;
+      }elseif($key == 'cn' && $conf['cnindn']){
         continue;
       }elseif(empty($entry[$key])){
         // field is empty -> handle deletion (except for photo unless deletion triggered)
@@ -203,7 +206,16 @@ print '</pre>';
         }
     }
 
-
+    if($conf['cnindn'] && !empty($entry['cn'][0])){
+      $newdn = preg_replace('/^(CN=)[^\,]+,/i', '${1}'.$entry['cn'][0].',', $dn);
+      if ($newdn != $dn) {
+        $r = @ldap_rename($LDAP_CON,$dn,'cn='.$entry['cn'][0],NULL,TRUE);
+        tpl_ldaperror("rename cn");
+        if ($r) {
+          $dn = $newdn;
+        }
+      }
+    }
     return $dn;
   }
 }

--- a/entry.php
+++ b/entry.php
@@ -131,10 +131,14 @@ function _saveData(){
   $dn    = $_REQUEST['dn'];
   //construct new dn
   $new_uid = time().str_pad(mt_rand(0,99999999),8,"0", STR_PAD_LEFT);
-  $newdn   = 'uid='.$new_uid;
+  $newdn = 'uid=';
+  if ($conf['cnasuid']) {
+    $newdn = 'cn=';
+  }
+  $newdn   .= $new_uid;
   if (empty($_REQUEST['type'])) { $_REQUEST['type']='public'; }
-  if($_REQUEST['type'] == 'private' && $conf['privatebook']){
-    $newdn .= ','.$conf['privatebook'].','.$_SESSION['ldapab']['binddn'];
+  if($_REQUEST['type'] == 'private' && $_SESSION['ldapab']['privatedn']){
+    $newdn .= ','.$_SESSION['ldapab']['privatedn'];
   }else{
     $newdn .= ','.$conf['publicbook'];
   }

--- a/inc/config.php
+++ b/inc/config.php
@@ -22,12 +22,6 @@
   // To match non-account entries try: (&(ou=%u)(objectClass=organizationalUnit))
   $conf['userfilter']  = '(&(uid=%u)(objectClass=posixAccount))';
 
-  // Bind with the provided username instead of the matched DN
-  $conf['bindwithusername'] = FALSE;
-
-  // Append this string to usernames when binding (if bindwithusername is set)
-  $conf['userrealm'] = '@example.ad';
-
   // Construct new entries with a DN including the CN rather than the UID
   $conf['cnasuid'] = FALSE;
 

--- a/inc/config.php
+++ b/inc/config.php
@@ -21,8 +21,8 @@
   // How to match users? %u is replaced by the given login
   $conf['userfilter']  = '(&(uid=%u)(objectClass=posixAccount))';
 
-  // Construct new entries with a DN including the CN rather than the UID
-  $conf['cnasuid'] = FALSE;
+  // Construct entries with a DN including the CN rather than the UID
+  $conf['cnindn'] = FALSE;
 
   // Show the users as contacts, too?
   $conf['displayusertree'] = 0;

--- a/inc/config.php
+++ b/inc/config.php
@@ -19,7 +19,17 @@
   $conf['usertree']    = 'ou=people, '.$conf['ldaprootdn'];
 
   // How to match users? %u is replaced by the given login
+  // To match non-account entries try: (&(ou=%u)(objectClass=organizationalUnit))
   $conf['userfilter']  = '(&(uid=%u)(objectClass=posixAccount))';
+
+  // Bind with the provided username instead of the matched DN
+  $conf['bindwithusername'] = FALSE;
+
+  // Append this string to usernames when binding (if bindwithusername is set)
+  $conf['userrealm'] = '@example.ad';
+
+  // Construct new entries with a DN including the CN rather than the UID
+  $conf['cnasuid'] = FALSE;
 
   // Show the users as contacts, too?
   $conf['displayusertree'] = 0;
@@ -39,6 +49,9 @@
 
   // Where to store private contacts (relative to $conf['usertree'])
   $conf['privatebook'] = 'ou=contacts';
+
+  // If set, takes precedence over the relative privatebook path (%u is replaced with the provided username)
+  #$conf['privatebook_absolute'] = 'ou=%u,'.$conf['publicbook'];
 
   // What fields to look at when searching?
   $conf['searchfields'] = array('uid','mail','name','givenname','o');

--- a/inc/config.php
+++ b/inc/config.php
@@ -19,7 +19,6 @@
   $conf['usertree']    = 'ou=people, '.$conf['ldaprootdn'];
 
   // How to match users? %u is replaced by the given login
-  // To match non-account entries try: (&(ou=%u)(objectClass=organizationalUnit))
   $conf['userfilter']  = '(&(uid=%u)(objectClass=posixAccount))';
 
   // Construct new entries with a DN including the CN rather than the UID

--- a/inc/fields.php
+++ b/inc/fields.php
@@ -22,7 +22,8 @@ $OCLASSES[] = 'inetOrgPerson';
 $FIELDS = array(
     'dn'           => 'dn',                          // don't touch!
     'name'         => 'sn',
-    'displayname'  => 'cn',
+    // For AD use displayName instead of CN -- AD requires CN in the DN so the CN must not change
+    'displayname'  => 'displayname',
     'givenname'    => 'givenName',
     'title'        => 'title',
     'organization' => 'o',                           // aka. company
@@ -40,7 +41,8 @@ $FIELDS = array(
     'url'          => 'labeledURI',
     'note'         => 'description',
     'manager'      => 'manager',                     // aka. key account
-    '_mail'        => 'mail',
+    // For AD use proxyAddresses instead of mail -- AD only supports a single mail address per inetOrgPerson
+    '_mail'        => 'proxyAddresses',
 );
 
 /**

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -89,11 +89,7 @@ function do_ldap_bind($user,$pass,$dn=""){
   }
 
   //bind with dn or username
-  $bindstring = $dn;
-  if ($conf['bindwithusername']) {
-    $bindstring = $user.$conf['userrealm'];
-  }
-  if(@ldap_bind($LDAP_CON,$bindstring,$pass)){
+  if(@ldap_bind($LDAP_CON,$dn,$pass)){
     //bind successful -> set up session
     set_session($user,$pass,$dn);
     return true;

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -88,8 +88,12 @@ function do_ldap_bind($user,$pass,$dn=""){
     $dn = $result[0]['dn'];
   }
 
-  //bind with dn
-  if(@ldap_bind($LDAP_CON,$dn,$pass)){
+  //bind with dn or username
+  $bindstring = $dn;
+  if ($conf['bindwithusername']) {
+    $bindstring = $user.$conf['userrealm'];
+  }
+  if(@ldap_bind($LDAP_CON,$bindstring,$pass)){
     //bind successful -> set up session
     set_session($user,$pass,$dn);
     return true;
@@ -131,10 +135,20 @@ function auth_browseruid(){
 function set_session($user,$pass,$dn){
   global $conf;
 
+  $privatedn = '';
+  if(!empty($dn)){
+    if($conf['privatebook_absolute']){
+      $privatedn = str_replace('%u',$user,$conf['privatebook_absolute']);
+    }elseif($conf['privatebook']){
+      $privatedn = $conf['privatebook'].','.$dn;
+    }
+  }
+
   $rand = rand();
   $_SESSION['ldapab']['username']  = $user;
   $_SESSION['ldapab']['binddn']    = $dn;
   $_SESSION['ldapab']['password']  = $pass;
+  $_SESSION['ldapab']['privatedn'] = $privatedn;
   $_SESSION['ldapab']['browserid'] = auth_browseruid();
 
   // (re)set the persistent auth cookie
@@ -394,9 +408,8 @@ function ldap_queryabooks($filter,$types){
   ldap_free_result($sr);
 
   // private addressbook
-  if(!empty($_SESSION['ldapab']['binddn']) && $conf['privatebook']){
-    $sr      = @ldap_list($LDAP_CON,$conf['privatebook'].
-                          ','.$_SESSION['ldapab']['binddn'],
+  if(!empty($_SESSION['ldapab']['privatedn'])){
+    $sr      = @ldap_list($LDAP_CON,$_SESSION['ldapab']['privatedn'],
                           $filter,$types);
     if(ldap_errno($LDAP_CON) != 32) tpl_ldaperror(); // ignore missing address book
     $result2 = ldap_get_binentries($LDAP_CON, $sr);

--- a/inc/template.php
+++ b/inc/template.php
@@ -141,9 +141,8 @@ function tpl_markers(){
   $sr = ldap_list($LDAP_CON,$conf['publicbook'],"ObjectClass=inetOrgPerson",array("marker"));
   $result1 = ldap_get_binentries($LDAP_CON, $sr);
   //check users private addressbook
-  if(!empty($_SESSION['ldapab']['binddn']) && $conf['privatebook']){
-    $sr = @ldap_list($LDAP_CON,
-                    $conf['privatebook'].','.$_SESSION['ldapab']['binddn'],
+  if(!empty($_SESSION['ldapab']['privatedn'])){
+    $sr = @ldap_list($LDAP_CON, $_SESSION['ldapab']['privatedn'],
                     "ObjectClass=inetOrgPerson",array("marker"));
     $result2 = ldap_get_binentries($LDAP_CON, $sr);
   }else{
@@ -205,9 +204,8 @@ function tpl_categories(){
   $sr = ldap_list($LDAP_CON,$conf['publicbook'],"ObjectClass=OXUserObject",array("OXUserCategories"));
   $result1 = ldap_get_binentries($LDAP_CON, $sr);
   //check users private addressbook
-  if(!empty($_SESSION['ldapab']['binddn']) && $conf['privatebook']){
-    $sr = @ldap_list($LDAP_CON,
-                    $conf['privatebook'].','.$_SESSION['ldapab']['binddn'],
+  if(!empty($_SESSION['ldapab']['privatedn'])){
+    $sr = @ldap_list($LDAP_CON, $_SESSION['ldapab']['privatedn'],
                     "ObjectClass=OXUserObject",array("OXUserCategories"));
     $result2 = ldap_get_binentries($LDAP_CON, $sr);
   }
@@ -243,9 +241,8 @@ function tpl_timezone(){
   $sr = ldap_list($LDAP_CON,$conf['publicbook'],"ObjectClass=OXUserObject",array("OXTimeZone"));
   $result1 = ldap_get_binentries($LDAP_CON, $sr);
   //check users private addressbook
-  if(!empty($_SESSION['ldapab']['binddn']) && $conf['privatebook']){
-    $sr = @ldap_list($LDAP_CON,
-                    $conf['privatebook'].','.$_SESSION['ldapab']['binddn'],
+  if(!empty($_SESSION['ldapab']['privatedn'])){
+    $sr = @ldap_list($LDAP_CON, $_SESSION['ldapab']['privatedn'],
                     "ObjectClass=OXUserObject",array("OXTimeZone"));
     $result2 = ldap_get_binentries($LDAP_CON, $sr);
   }
@@ -281,9 +278,8 @@ function tpl_country(){
   $sr = ldap_list($LDAP_CON,$conf['publicbook'],"ObjectClass=OXUserObject",array("userCountry"));
   $result1 = ldap_get_binentries($LDAP_CON, $sr);
   //check users private addressbook
-  if(!empty($_SESSION['ldapab']['binddn']) && $conf['privatebook']){
-    $sr = @ldap_list($LDAP_CON,
-                    $conf['privatebook'].','.$_SESSION['ldapab']['binddn'],
+  if(!empty($_SESSION['ldapab']['privatedn'])){
+    $sr = @ldap_list($LDAP_CON, $_SESSION['ldapab']['privatedn'],
                     "ObjectClass=OXUserObject",array("userCountry"));
     $result2 = ldap_get_binentries($LDAP_CON, $sr);
   }

--- a/login.php
+++ b/login.php
@@ -11,13 +11,18 @@ if(!empty($_REQUEST['username'])){
     if (do_ldap_bind($_REQUEST['username'],$_REQUEST['password'])){
 
         //create private address book if simple enough
-        if(preg_match('/ou=([^,]+)$/',$conf['privatebook'],$match)){
-            $privatedn = $conf['privatebook'].', '.$_SESSION['ldapab']['binddn'];
-            if(!@ldap_read($LDAP_CON,$privatedn,'')){
-                @ldap_add($LDAP_CON,$privatedn,
-                         array('objectClass' => array ('organizationalUnit','top'),
-                               'ou' => $match[1]));
-            }
+        if(!ldap_read($LDAP_CON,$_SESSION['ldapab']['privatedn'],'')){
+          $ou = '';
+          if($conf['privatebook_absolute'] && preg_match('/^ou=%u,/',$conf['privatebook_absolute'])){
+            $ou = $_SESSION['ldapab']['username'];
+          }else if(!$conf['privatebook_absolute'] && preg_match('/ou=([^,]+)$/',$conf['privatebook'],$match)){
+            $ou = $match[1];
+          }
+          if(!empty($ou)) {
+            ldap_add($LDAP_CON,$_SESSION['ldapab']['privatedn'],
+                     array('objectClass' => array ('organizationalUnit','top'),
+                           'ou' => $ou));
+          }
         }
 
         //forward to next page


### PR DESCRIPTION
I've added support for ActiveDirectory as an LDAP server.

More generally, I've added the (configurable) ability to:
1. Use a private address book that's not a child of the BINDDN. In AD standard users cannot be the parents of OU objects, but this would be useful to anyone who didn't want to put private address books in their user tree, even on slapd or other servers.
2. Create new entries with a DN in the form of "CN=random,..." instead of "UID=random,...". This is an AD-specific fix required because you cannot create inetOrgPerson objects in AD without putting the CN in the DN.
